### PR TITLE
Remove normalized class names

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = class BlurNSFW extends Plugin {
 		let _this = this;
 		const Channels = await getModuleByDisplayName("Channels")
 		inject("cadence-blurnsfw-channellist", Channels.prototype, "render", function(_, res) {
-			let chat = document.querySelector(".pc-chat")
+			let chat = document.querySelector(".chat-3bRxxu")
 			if (chat && !_this.patchedRenderer) {
 				_this._patchChannelRenderer(chat)
 				_this.patchedRenderer = true

--- a/style.scss
+++ b/style.scss
@@ -1,18 +1,18 @@
-.pc-chat.is-nsfw-channel .pc-imageWrapper {
+.chat-3bRxxu.is-nsfw-channel .imageWrapper-2p5ogY {
     position: relative;
 }
 
 
-.pc-chat.is-nsfw-channel .pc-imageWrapper img {
+.chat-3bRxxu.is-nsfw-channel .imageWrapper-2p5ogY img {
     filter: blur(20px);
     position: relative;
 }
 
-.pc-chat.is-nsfw-channel .pc-imageWrapper:hover img {
+.chat-3bRxxu.is-nsfw-channel .imageWrapper-2p5ogY:hover img {
     filter: none;
 }
 
-.pc-chat.is-nsfw-channel .pc-imageWrapper::after {
+.chat-3bRxxu.is-nsfw-channel .imageWrapper-2p5ogY::after {
     content: "NSFW";
     position: absolute;
     display: block;
@@ -28,6 +28,6 @@
     transform: translate(-50%, -50%);
 }
 
-.pc-chat.is-nsfw-channel .pc-imageWrapper:hover::after {
+.chat-3bRxxu.is-nsfw-channel .imageWrapper-2p5ogY:hover::after {
     display: none;
 }


### PR DESCRIPTION
Switch to abstract class names because normalized class names are no longer supported